### PR TITLE
Multi-channel support

### DIFF
--- a/src/main/kotlin/com/github/frozensync/games/wordsnake/Commands.kt
+++ b/src/main/kotlin/com/github/frozensync/games/wordsnake/Commands.kt
@@ -1,5 +1,5 @@
 package com.github.frozensync.games.wordsnake
 
-internal data class CreateGameCommand(val playerNames: List<String>)
-internal data class AppendWordCommand(val word: String)
-internal class UndoTurnCommand
+internal data class CreateGameCommand(val channelId: Long, val playerNames: List<String>)
+internal data class AppendWordCommand(val channelId: Long, val word: String)
+internal data class UndoTurnCommand(val channelId: Long)

--- a/src/main/kotlin/com/github/frozensync/games/wordsnake/Events.kt
+++ b/src/main/kotlin/com/github/frozensync/games/wordsnake/Events.kt
@@ -6,10 +6,10 @@ import kotlinx.serialization.Serializable
 internal sealed class Event
 
 @Serializable
-internal data class GameCreatedEvent(val players: List<Player>) : Event()
+internal data class GameCreatedEvent(val channelId: Long, val players: List<Player>) : Event()
 
 @Serializable
-internal data class WordAppendedEvent(val word: String) : Event() // TODO add player
+internal data class WordAppendedEvent(val channelId: Long, val word: String) : Event() // TODO add player
 
 @Serializable
-internal data class WordUndoneEvent(val removedWord: String, val currentWord: String) : Event()
+internal data class WordUndoneEvent(val channelId: Long, val removedWord: String, val currentWord: String) : Event()

--- a/src/main/kotlin/com/github/frozensync/games/wordsnake/WordSnakeRepository.kt
+++ b/src/main/kotlin/com/github/frozensync/games/wordsnake/WordSnakeRepository.kt
@@ -20,14 +20,14 @@ internal object InMemoryWordSnakeRepository : WordSnakeRepository {
     }
 
     override fun on(event: GameCreatedEvent) {
-        map[0L] = WordSnake().also { it.apply(event) }
+        map[event.channelId] = WordSnake(event)
     }
 
     override fun on(event: WordAppendedEvent) {
-        map[0L]?.apply(event)
+        map[event.channelId]?.apply(event)
     }
 
     override fun on(event: WordUndoneEvent) {
-        map[0L]?.apply(event)
+        map[event.channelId]?.apply(event)
     }
 }


### PR DESCRIPTION
Enable one game per channel

Refactor aggregate `WordSnake`. `GameCreatedEvent` is now handled in the constructor  to allow for `val` fields.