### PR TITLE
feat: add timer to WordSnake

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
 
 tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = "11"
-    kotlinOptions.freeCompilerArgs += "-Xinline-classes"
+    kotlinOptions.freeCompilerArgs += listOf("-Xinline-classes", "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")
 }
 
 tasks.withType<Test> {

--- a/src/main/kotlin/com/github/frozensync/Main.kt
+++ b/src/main/kotlin/com/github/frozensync/Main.kt
@@ -1,6 +1,7 @@
 package com.github.frozensync
 
 import com.github.frozensync.command.CommandHandler
+import com.github.frozensync.discord.discordModule
 import com.github.frozensync.games.wordsnake.wordSnakeModule
 import com.github.frozensync.persistence.mongodb.mongoModule
 import discord4j.core.DiscordClient
@@ -21,15 +22,11 @@ private val logger = KotlinLogging.logger { }
 fun main() = runBlocking<Unit> {
     val koinApplication = startKoin {
         environmentProperties()
-        modules(wordSnakeModule, mongoModule)
+        modules(discordModule, wordSnakeModule, mongoModule)
     }
     val koin = koinApplication.koin
-    val token = koin.getProperty("YGGDRASIL_TOKEN") ?: run {
-        logger.error { "Environment variable not found: YGGDRASIL_TOKEN" }
-        exitProcess(1)
-    }
 
-    DiscordClient.create(token).withGateway { client ->
+    koin.get<DiscordClient>().withGateway { client ->
         mono {
             launch { client.on(MessageCreateEvent::class.java).addListener(CommandHandler::executeCommands) }
         }

--- a/src/main/kotlin/com/github/frozensync/discord/Module.kt
+++ b/src/main/kotlin/com/github/frozensync/discord/Module.kt
@@ -1,0 +1,8 @@
+package com.github.frozensync.discord
+
+import discord4j.core.DiscordClient
+import org.koin.dsl.module
+
+val discordModule = module {
+    single { DiscordClient.create(getProperty("YGGDRASIL_TOKEN")) }
+}

--- a/src/main/kotlin/com/github/frozensync/games/wordsnake/DisqualificationTimer.kt
+++ b/src/main/kotlin/com/github/frozensync/games/wordsnake/DisqualificationTimer.kt
@@ -1,0 +1,32 @@
+package com.github.frozensync.games.wordsnake
+
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+
+internal class DisqualificationTimer(
+    private val time: Long, // ms
+    private val wordSnakeRepository: WordSnakeRepository,
+    private val notificationChannel: Channel<WordSnake>,
+) {
+    private val action: suspend (Long) -> Unit = { id ->
+        wordSnakeRepository.findById(id)
+            ?.removePlayer()
+            ?.let {
+                wordSnakeRepository.save(it)
+                notificationChannel.send(it)
+            }
+    }
+
+    private var job: Deferred<Unit>? = null
+
+    suspend fun start(id: Long) {
+        job?.cancel()
+        job = GlobalScope.async {
+            delay(time)
+            action.invoke(id)
+        }
+    }
+}

--- a/src/main/kotlin/com/github/frozensync/games/wordsnake/Module.kt
+++ b/src/main/kotlin/com/github/frozensync/games/wordsnake/Module.kt
@@ -3,6 +3,8 @@ package com.github.frozensync.games.wordsnake
 import org.koin.dsl.module
 
 val wordSnakeModule = module {
-    single<WordSnakeRepository> { WordSnakeRepositoryMongoDB(get()) }
-    single { WordSnakeCommandSet(get()) }
+    single { WordSnakeCommandSet(get(), get()) }
+
+    single { WordSnakeRepositoryMongoDB(get()) }
+    single<WordSnakeRepository> { WordSnakeCachedMongoRepository(get()) }
 }

--- a/src/main/kotlin/com/github/frozensync/games/wordsnake/WordSnake.kt
+++ b/src/main/kotlin/com/github/frozensync/games/wordsnake/WordSnake.kt
@@ -19,15 +19,18 @@ internal data class WordSnake(
     val currentPlayer: Player? = players.firstOrNull(),
     val words: Set<String> = persistentSetOf(),
     val currentWord: String? = null,
-    val turn: Int = 1
+    val turn: Int = 1,
+    @Transient val timer: DisqualificationTimer?,
 ) {
-    fun appendWord(word: String): WordSnake {
+    suspend fun appendWord(word: String): WordSnake {
         when {
             isFinished() -> return this
             currentWord != null && currentWord.last() != word.first() -> throw InvalidWordException(""""$word" does not start with the last letter of "$currentWord".""")
             words.contains(word) -> throw InvalidWordException(""""$word" has already been used.""")
             !DICTIONARY.contains(word) -> throw InvalidWordException(""""$word" is not in the dictionary.""")
         }
+
+        timer?.start(id)
 
         return copy(
             currentPlayer = nextPlayer(),

--- a/src/main/kotlin/com/github/frozensync/games/wordsnake/WordSnakeCachedMongoRepository.kt
+++ b/src/main/kotlin/com/github/frozensync/games/wordsnake/WordSnakeCachedMongoRepository.kt
@@ -1,0 +1,24 @@
+package com.github.frozensync.games.wordsnake
+
+import java.util.concurrent.ConcurrentHashMap
+
+internal class WordSnakeCachedMongoRepository(
+    private val mongoRepository: WordSnakeRepositoryMongoDB
+) : WordSnakeRepository {
+
+    private val map = ConcurrentHashMap<Long, WordSnake>()
+
+    override suspend fun findById(id: Long): WordSnake? = map[id] ?: mongoRepository.findById(id)
+
+    override suspend fun existsById(id: Long): Boolean = map.containsKey(id) || mongoRepository.existsById(id)
+
+    override suspend fun save(game: WordSnake) {
+        map[game.id] = game
+        mongoRepository.save(game)
+    }
+
+    override suspend fun delete(game: WordSnake) {
+        map.remove(game.id)
+        mongoRepository.delete(game)
+    }
+}


### PR DESCRIPTION
Refactor `DiscordClient` such that it's a Koin component so `WordSnakeCommandSet.kt` can retrieve it for its `gameOverListener`.

Closes #9 